### PR TITLE
Changed elm-package.json to be compatible with elm 0.15. Bumped version to 1.1.0.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.2",
+    "version": "1.1.0",
     "summary": "A signal that is synchronized with the monitor's frame rate.",
     "repository": "https://github.com/jwmerrill/elm-animation-frame.git",
     "license": "BSD3",
@@ -10,7 +10,8 @@
         "AnimationFrame"
     ],
     "native-modules": true,
+    "elm-version": "0.14.0 <= v < 0.16.0",
     "dependencies": {
-        "elm-lang/core": "1.0.0 <= v < 2.0.0"
+        "elm-lang/core": "1.0.0 <= v < 3.0.0"
     }
 }


### PR DESCRIPTION
The code itself is already compatible, but elm-package.json needed elm-lang/core upgraded to 2.0 and an extra line for elm-version 0.15.

I thought this warranted bumping the version to 1.1.0. Let me know what you think.
