### PR TITLE
Add a Task which waits for a callback from requestAnimationFrame().

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This library provides time Signals that are synchronized to the monitor's frame rate, by binding javascript's requestAnimationFrame. Using `AnimationFrame.frame` or `AnimationFrame.frameWhen` instead of `(Time.fps 60)` or `(Time.fpsWhen 60)` makes it possible (but not guaranteed...) to achieve 60 fps animation without stutter in Elm.
 
+You can also use `AnimationFrame.wait` to synchronize Tasks with the monitor's frame rate.
+
 ## Example Usage
 
 ```elm
@@ -13,6 +15,8 @@ main = Signal.map Text.asText (Signal.foldp (+) 0 AnimationFrame.frame)
 ```
 
 See `examples/counter.elm` for a minimal working example that uses both `AnimationFrame.frame` and `AnimationFrame.frameWhen`. You can see this example in action [here](http://squishythinking.com/elm-animation-frame/examples/counter.html). The top counter uses `AnimationFrame.frame` to count continuously. The bottom counter uses `AnimationFrame.frameWhen` to count only when the mouse is down.
+
+See `examples/task.elm` for a minimal working example that uses `Animation.wait` to control when a task executes.
 
 ## Performance Comparison
 

--- a/examples/task.elm
+++ b/examples/task.elm
@@ -1,0 +1,61 @@
+import AnimationFrame
+import Signal exposing (Mailbox, mailbox, message)
+import Time exposing (Time)
+import Graphics.Element exposing (Element, flow, down, show)
+import Graphics.Input exposing (button)
+import Task exposing (Task, andThen)
+
+
+type Action
+    = RequestTick
+    | ReceiveTick Time
+    | NoOp
+
+
+type alias Model = List Time
+
+
+actions : Mailbox Action
+actions = Signal.mailbox NoOp
+
+
+update : Action -> Model -> Model
+update action model =
+    case action of
+        ReceiveTick interval ->
+            interval :: model
+
+        _ ->
+            model
+
+
+reaction : Action -> Maybe (Task () ())
+reaction action =
+    case action of
+        RequestTick ->
+            Just <|
+                AnimationFrame.wait
+                    `andThen` (Signal.send actions.address << ReceiveTick)
+
+        _ ->
+            Nothing
+
+
+view : Model -> Element
+view model =
+    flow down <|
+        button (message actions.address RequestTick) "Request Animation Frame"
+        ::
+        List.map show model
+
+
+models : Signal Model
+models = Signal.foldp update [] actions.signal
+
+
+main : Signal Element
+main = Signal.map view models
+
+
+port reactions : Signal (Task () ())
+port reactions = Signal.filterMap reaction (Task.succeed ()) actions.signal 

--- a/src/AnimationFrame.elm
+++ b/src/AnimationFrame.elm
@@ -1,18 +1,25 @@
 module AnimationFrame where
+
 {-| This library is modeled after Elm's time module. It provides Signals that
 are synchronized with the monitor's frame rate by binding javascript's
 requestAnimationFrame. `AnimationFrame.frame` and `AnimationFrame.frameWhen` are similar
 to `(Time.fps 60)` and `(Time.fpsWhen 60)` respectively, but they more reliably
 fire once per frame.
 
+You can also use `wait` to synchronize tasks with the monitor's frame rate.
+
 #Tickers
 @docs frame, frameWhen
--}
 
+#Task
+@docs wait
+-}
 
 import Native.AnimationFrame
 import Signal
-import Time
+import Time exposing (Time)
+import Task exposing (Task)
+
 
 {-| Same as the frame function, but you can turn it on and off. Allows you
 to do brief animations based on user input without major inefficiencies.
@@ -29,3 +36,12 @@ Note that "once per frame" is an intent, not a guarantee.
 -}
 frame : Signal.Signal Time.Time
 frame = frameWhen (Signal.constant True)
+
+
+{-| A task which waits until an animation frame is needed, and then reports the
+`Time` provided by the browser to the `requestAnimationFrame` callback. To use
+this task, you would typically add an `andThen` to do something when the
+animation frame is needed, possibly using the reported `Time`.
+-}
+wait : Task x Time
+wait = Native.AnimationFrame.wait

--- a/src/Native/AnimationFrame.js
+++ b/src/Native/AnimationFrame.js
@@ -7,6 +7,7 @@ Elm.Native.AnimationFrame.make = function(localRuntime) {
 
   var Signal = Elm.Signal.make(localRuntime);
   var NS = Elm.Native.Signal.make(localRuntime);
+  var Task = Elm.Native.Task.make(localRuntime);
 
   // TODO Should be localRuntime.requestAnimationFrame, and should be shimmed if we care
   // about IE9. Do we care about IE9?
@@ -39,8 +40,15 @@ Elm.Native.AnimationFrame.make = function(localRuntime) {
     return A3(Signal.map2, F2(f), isOn, ticker);
   }
 
+  var wait = Task.asyncFunction(function(callback) {
+    requestAnimationFrame(function(time) {
+      callback(Task.succeed(time));
+    });
+  });
+
   return localRuntime.Native.AnimationFrame.values = {
-    frameWhen : frameWhen
+    frameWhen : frameWhen,
+    wait : wait
   };
 
 };


### PR DESCRIPTION
The purpose of this pull request would be to provide a way to synchronize the execution of a Task with the monitor's frame rate.

This is essentially an alternative to using requestAnimationFrame() via a Signal. So, it is useful in cases where one's API is Task-oriented rather than Signal-oriented.

The native code included here was inspired by this code in evancz/elm-effects:

https://github.com/evancz/elm-effects/blob/master/src/Native/Effects.js

However, the code here aims to improve upon that code in two ways:
- The native code in elm-effects is not exposed, so it is not possible for other packages to build on it. (That could be cured if [this pull request](https://github.com/evancz/elm-effects/pull/13) were accepted).
- The native code in elm-effects is needlessly complex. It takes a function `Time -> Task` as a parameter, in order to be able to do something with the value provided by requestAnimationFrame() in its callback. However, this is, on reflection, unnecessary -- all that is needed is to expose a `Task x Time`, and the clients of this API can supply an `andThen` if they want to do something that depends on the value supplied in the callback. (Or, to put it another way, we don't need to invent a new way of doing composition of Tasks here).

For an additional example of using this code, see:

https://github.com/rgrempel/elm-ticker

Note that I have requested [native review](https://github.com/elm-lang/package.elm-lang.org/issues/71) of that package. However, @laszlopandy sensibly suggested that the necessary code be added here instead, in order to consolidate the required native code in a smaller number of packages. I originally suggested merely [exposing requestAnimationFrame in elm-effects](https://github.com/evancz/elm-effects/pull/13) instead. However, now that I have improved on that code, I would now suggest including that improved version here instead, via this pull request. 
